### PR TITLE
fix an inconsistency between running commands in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,21 +68,21 @@ GraphFuzz is implemented as a custom mutation engine on top of libFuzzer and as 
 1. Use `gfuzz` to synthesize C++ harness files from your `schema.yaml` harness spec.
 
 ```
-gfuzz gen cpp schema.yaml ./output
+gfuzz gen cpp schema.yaml .
 ```
 
-2. Compile the generated harness files as standard libFuzzer harnesses (`-fsanitize=fuzzer`) and link libgraphfuzz and protobuf dependencies (`-lgraphfuzz -lproto`). Optionally, include any extra sanitizers (ASAN, UBSAN, TSAN, etc...). GraphFuzz will actually create two mirror harnesses: `fuzz_exec` is used for fuzzing and actually invokes the library API while `fuzz_write` generates equivalent source code for a given dataflow graph.
+2. Compile the generated harness files as standard libFuzzer harnesses (`-fsanitize=fuzzer`) and link libgraphfuzz and protobuf dependencies (`-lgraphfuzz -lprotobuf`). Optionally, include any extra sanitizers (ASAN, UBSAN, TSAN, etc...). GraphFuzz will actually create two mirror harnesses: `fuzz_exec` is used for fuzzing and actually invokes the library API while `fuzz_write` generates equivalent source code for a given dataflow graph.
 
 ```bash
 # fuzz_exec: main fuzzer, executes test cases
-clang++ ./output/fuzz_exec.cpp \
-    -lmylib -lgraphfuzz -lproto \
+clang++ fuzz_exec.cpp \
+    -lgraphfuzz -lprotobuf \
     -fsanitize=address,fuzzer \
     -o fuzz_exec
 
 # fuzz_write: converts test cases to source code
-clang++ ./output/fuzz_write.cpp \
-    -lmylib -lgraphfuzz -lproto \
+clang++ fuzz_write.cpp \
+    -lgraphfuzz -lprotobuf \
     -fsanitize=address,fuzzer \
     -o fuzz_write
 ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ clang++ fuzz_write.cpp \
     -o fuzz_write
 ```
 
-3. Run the generated binary with any standard libFuzzer command-line arguments. In addition, there are several additional GraphFuzz-specific arguments prefixed with `--graphfuzz-`. Crash reports are identical to standard libFuzzer reports.
+3. Run the generated binary with any standard libFuzzer command-line arguments. In addition, there are several additional GraphFuzz-specific arguments prefixed with `--graphfuzz_`. Crash reports are identical to standard libFuzzer reports.
 
 ```
 $ ./fuzz_exec

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,26 +68,26 @@ GraphFuzz is implemented as a custom mutation engine on top of libFuzzer and as 
 1. Use `gfuzz` to synthesize C++ harness files from your `schema.yaml` harness spec.
 
 ```
-gfuzz gen cpp schema.yaml ./output
+gfuzz gen cpp schema.yaml .
 ```
 
-2. Compile the generated harness files as standard libFuzzer harnesses (`-fsanitize=fuzzer`) and link libgraphfuzz and protobuf dependencies (`-lgraphfuzz -lproto`). Optionally, include any extra sanitizers (ASAN, UBSAN, TSAN, etc...). GraphFuzz will actually create two mirror harnesses: `fuzz_exec` is used for fuzzing and actually invokes the library API while `fuzz_write` generates equivalent source code for a given dataflow graph.
+2. Compile the generated harness files as standard libFuzzer harnesses (`-fsanitize=fuzzer`) and link libgraphfuzz and protobuf dependencies (`-lgraphfuzz -lprotobuf`). Optionally, include any extra sanitizers (ASAN, UBSAN, TSAN, etc...). GraphFuzz will actually create two mirror harnesses: `fuzz_exec` is used for fuzzing and actually invokes the library API while `fuzz_write` generates equivalent source code for a given dataflow graph.
 
 ```bash
 # fuzz_exec: main fuzzer, executes test cases
-clang++ ./output/fuzz_exec.cpp \
-    -lmylib -lgraphfuzz -lproto \
+clang++ fuzz_exec.cpp \
+    -lgraphfuzz -lprotobuf \
     -fsanitize=address,fuzzer \
     -o fuzz_exec
 
 # fuzz_write: converts test cases to source code
-clang++ ./output/fuzz_write.cpp \
-    -lmylib -lgraphfuzz -lproto \
+clang++ fuzz_write.cpp \
+    -lgraphfuzz -lprotobuf \
     -fsanitize=address,fuzzer \
     -o fuzz_write
 ```
 
-3. Run the generated binary with any standard libFuzzer command-line arguments. In addition, there are several additional GraphFuzz-specific arguments prefixed with `--graphfuzz-`. Crash reports are identical to standard libFuzzer reports.
+3. Run the generated binary with any standard libFuzzer command-line arguments. In addition, there are several additional GraphFuzz-specific arguments prefixed with `--graphfuzz_`. Crash reports are identical to standard libFuzzer reports.
 
 ```
 $ ./fuzz_exec


### PR DESCRIPTION
In readme, there is an inconsistency between the running commands about using Graphfuzz.
After running `gfuzz gen cpp schema.yaml ./output`, the file `schema.json` will be put into `./output` with `fuzz_exec.cpp` and `fuzz_write.cpp` together. Therefore, when running `./fuzz_exec`, we should add `--graphfuzz_schema=./output/schema.json`.
However, considering the running log below is loading `schema.json` rather than `./output/schema.json`, it is better to directly change `gfuzz gen cpp schema.yaml ./output` to `gfuzz gen cpp schema.yaml .` to maintain consistency without modifying the original runnign log.
By the way, looks like it should be `-lprotobuf` to link protobuf and it is unnecessary to retain `-lmylib`.