### PR TITLE
prevent libfuzzer checking for memory leak, fixes harness running twice

### DIFF
--- a/cli/gfuzz/commands/gen/cpp/gen_cpp.py
+++ b/cli/gfuzz/commands/gen/cpp/gen_cpp.py
@@ -177,7 +177,14 @@ SHIM_HEADER_WRITE = '''
 
 unsigned long CURR_ID = 0;
 
-extern "C" void __attribute__((visibility ("default"))) global_init(int *argc, char ***argv) {{ }}
+extern "C" void __attribute__((visibility ("default"))) global_init(int *argc, char ***argv) {{
+    char **new_argv = (char **)malloc((*argc + 2) * sizeof(char *));
+    memcpy(new_argv, *argv, sizeof(*new_argv) * *argc);
+    new_argv[*argc] = (char *)"-detect_leaks=0";
+    new_argv[*argc + 1] = 0;
+    (*argc)++;
+    *argv = new_argv;
+}}
 
 extern "C" void __attribute__((visibility ("default"))) shim_init() {{
     CURR_ID = 0;


### PR DESCRIPTION
As discussed in #11 this fixes the writer harness from running twice.

I checked this in my own projects [container_builder](https://github.com/NikLeberg/container_builder/actions/runs/4355580148/jobs/7612397858) and [tdd-platform](https://github.com/NikLeberg/tdd-platform/tree/fbef65d32317bedced36389d0947ad394603691c/tests/fuzzing/buggy_api_graphfuzz), everything should work fine.

Cheers,
Nik

